### PR TITLE
Updating bundle sync to use snapshots that have been released

### DIFF
--- a/scripts/bundle_sync.sh
+++ b/scripts/bundle_sync.sh
@@ -24,7 +24,8 @@ source scripts/util.sh
 : "${TARGET_REPO:=kubev2v/forklift}"
 
 # Extraction script paths
-: "${LATEST_SNAPSHOT_SCRIPT:=./scripts/latest_snapshot.sh}"
+: "${LATEST_RELEASE_SCRIPT:=./scripts/latest_release.sh}"
+: "${SNAPSHOT_FROM_RELEASE_SCRIPT:=./scripts/snapshot_from_release.sh}"
 : "${SNAPSHOT_CONTENT_SCRIPT:=./scripts/snapshot_content.sh}"
 
 # Component mapping configuration file (default: same directory as this script)
@@ -59,8 +60,10 @@ get_latest_snapshot() {
     local version="$1"
     
     # Use the configured snapshot script
+    local latest_release
+    latest_release=$("$LATEST_RELEASE_SCRIPT" "$version" "stage" 2>/dev/null)
     local snapshot_name
-    snapshot_name=$("$LATEST_SNAPSHOT_SCRIPT" "$version" 2>/dev/null)
+    snapshot_name=$("$SNAPSHOT_FROM_RELEASE_SCRIPT" "$latest_release" 2>/dev/null)
     
     if [ -z "$snapshot_name" ]; then
         echo "ERROR: No snapshot found for version: $version" >&2

--- a/scripts/latest_release.sh
+++ b/scripts/latest_release.sh
@@ -17,7 +17,7 @@ if [[ -z $1 || -z $2 ]]; then
 fi
 
 if [[ -z $3 ]]; then
-    oc get releases --sort-by={.metadata.creationTimestamp} | grep Succeeded | tac | grep $version | grep rp-$target | awk '{print $1}' | head -n 1
+    oc get releases --sort-by={.metadata.creationTimestamp} | grep Succeeded | grep forklift-operator-$version | grep rp-$target | awk '{print $1}' | tail -n 1
 else
-    oc get releases --sort-by={.metadata.creationTimestamp} | grep Succeeded | tac | grep $version | grep rp-$target | grep '\-rhel'$rhel | awk '{print $1}' | head -n 1
+    oc get releases --sort-by={.metadata.creationTimestamp} | grep Succeeded | grep forklift-operator-$version | grep rp-$target | grep '\-rhel'$rhel | awk '{print $1}' | tail -n 1
 fi

--- a/scripts/latest_snapshot.sh
+++ b/scripts/latest_snapshot.sh
@@ -14,4 +14,4 @@ if [[ -z $1 ]]; then
 fi
 
 
-oc get snapshots --sort-by='{.metadata.creationTimestamp}' -o custom-columns=NAME:.metadata.name | grep $version | tail -n 1
+oc get snapshots --sort-by='{.metadata.creationTimestamp}' -o custom-columns=NAME:.metadata.name | grep forklift-operator-$version | tail -n 1


### PR DESCRIPTION
Should just be using existing scripts to only pull snapshots from successful releases so PR snapshots don't get picked up by accident