### PR TITLE
Defaulting to empty mapping if nothing is found

### DIFF
--- a/mtv_pipelines/wrappers/jenkins_analyzer.py
+++ b/mtv_pipelines/wrappers/jenkins_analyzer.py
@@ -38,7 +38,7 @@ class JenkinsAnalyzer:
         self, data: dict, job_result: JenkinsJobResultDTO
     ) -> JenkinsJobAnalysisDTO:
         children = []
-        for child in data["child_job_analyses"]:
+        for child in data.get("child_job_analyses", []):
             children.append(
                 JenkinsChildJobAnalysisDTO(
                     job_name=child["job_name"],


### PR DESCRIPTION
Automation has been failing with the following:
```
{"level":"ERROR","time":"2026-03-31 05:03:42,273","source":"__main__","msg":"  + Exception Group Traceback (most recent call last):\n  |   File \"/app/mtv_pipelines/main.py\", line 182, in <module>\n  |     run()\n  |     ~~~^^\n  |   File \"/app/mtv_pipelines/main.py\", line 177, in run\n  |     exec_pipeline(args)\n  |     ~~~~~~~~~~~~~^^^^^^\n  |   File \"/app/mtv_pipelines/main.py\", line 170, in exec_pipeline\n  |     asyncio.run(pipeline.start())\n  |     ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^\n  |   File \"/usr/local/lib/python3.14/asyncio/runners.py\", line 204, in run\n  |     return runner.run(main)\n  |            ~~~~~~~~~~^^^^^^\n  |   File \"/usr/local/lib/python3.14/asyncio/runners.py\", line 127, in run\n  |     return self._loop.run_until_complete(task)\n  |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^\n  |   File \"/usr/local/lib/python3.14/asyncio/base_events.py\", line 719, in run_until_complete\n  |     return future.result()\n  |            ~~~~~~~~~~~~~^^\n  |   File \"/app/mtv_pipelines/core/pipeline.py\", line 232, in start\n  |     async with asyncio.TaskGroup() as tg:\n  |                ~~~~~~~~~~~~~~~~~^^\n  |   File \"/usr/local/lib/python3.14/asyncio/taskgroups.py\", line 72, in __aexit__\n  |     return await self._aexit(et, exc)\n  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  |   File \"/usr/local/lib/python3.14/asyncio/taskgroups.py\", line 174, in _aexit\n  |     raise BaseExceptionGroup(\n  |     ...<2 lines>...\n  |     ) from None\n  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)\n  +-+---------------- 1 ----------------\n    | Traceback (most recent call last):\n    |   File \"/app/mtv_pipelines/core/pipeline.py\", line 194, in _run_task\n    |     output_data = await task.run(input_data, self.args, self.tg)\n    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    |   File \"/app/mtv_pipelines/core/task.py\", line 56, in run\n    |     return await self.func(data, args, tg)\n    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    |   File \"/app/mtv_pipelines/pipelines/automatic_iib.py\", line 683, in analyze_jobs\n    |     results.append(ja.analyze_job(job))\n    |                    ~~~~~~~~~~~~~~^^^^^\n    |   File \"/app/mtv_pipelines/wrappers/jenkins_analyzer.py\", line 33, in analyze_job\n    |     analysis = self._process_data(data, job_result)\n    |   File \"/app/mtv_pipelines/wrappers/jenkins_analyzer.py\", line 41, in _process_data\n    |     for child in data[\"child_job_analyses\"]:\n    |                  ~~~~^^^^^^^^^^^^^^^^^^^^^^\n    | KeyError: 'child_job_analyses'\n    +------------------------------------\n"}
```

Making this change to try to alleviate until a more comprehensive fix is found.