### PR TITLE
Enable email notifications for CI-triggered copyoffload jobs

### DIFF
--- a/mtv_pipelines/wrappers/jenkins.py
+++ b/mtv_pipelines/wrappers/jenkins.py
@@ -122,6 +122,7 @@ class JenkinsManager:
             "PYTEST_EXTRA_PARAMS": '-k "not (TestCopyoffload2TbVmSnapshotsMigration or TestCopyoffloadLargeVmMigration or TestCopyoffloadScaleMigration)"',
             "GIT_BRANCH": "main",
             "MTV_API_TEST_GIT_USER": "RedHatQE",
+            "SEND_EMAIL_ON_COMPLETION": True,
         }
 
     def get_test_release_gate_args(


### PR DESCRIPTION
Add SEND_EMAIL_ON_COMPLETION parameter to get_storage_offload_args() to automatically send email notifications to mtv-qe@redhat.com when copyoffload tests complete in CI-triggered jobs.

This affects all automated copyoffload jobs for MTV 2.11 and 2.12. Manual job runs will still have the checkbox unchecked by default.