### PR TITLE
Storage offload: per-MTV cluster host, API URL, and password env

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ make run        # run the container
 | `JENKINS_TOKEN` | Jenkins API token |
 | `REGISTRY_PROD_USER` / `REGISTRY_PROD_TOKEN` | Production registry credentials |
 | `REGISTRY_STAGE_USER` / `REGISTRY_STAGE_TOKEN` | Stage registry credentials |
-| `STORAGE_OFFLOAD_CLUSTER` | Storage offload cluster password (optional) |
+| `STORAGE_OFFLOAD_CLUSTER` | Kubeadmin password for the default storage offload cluster (optional) |
+| `STORAGE_OFFLOAD_CLUSTER_EDGE113` | Kubeadmin password for ocp-edge113 (MTV 2.12+, optional) |
 | `ROOTCOZ` | Rootcoz Bearer token for the Jenkins analyzer API |
 
 ---
@@ -247,3 +248,24 @@ All tunable settings live in [`mtv_pipelines/config/config.yaml`](mtv_pipelines/
 - Registry namespaces
 - Component mappings (`cmp_mappings`) — downstream name → upstream + git origin
 - Commit character limit for Slack messages
+- Storage offload cluster mappings (`storage_offload_clusters`) — MTV x.y → cluster name, API URL, OCP version, and `password_env`
+
+### Storage offload clusters
+
+The `storage_offload_clusters` map in `config.yaml` controls which cluster is used for copyoffload tests per MTV minor version:
+
+```yaml
+storage_offload_clusters:
+  "2.11":
+    custom_cluster_name: "ocp-edge112"
+    ocp_api_url: "https://api.ocp-edge112-0.lab.eng.tlv2.redhat.com:6443"
+    ocp_version: "4.20"
+    password_env: "STORAGE_OFFLOAD_CLUSTER"
+  "2.12":
+    custom_cluster_name: "ocp-edge113"
+    ocp_api_url: "https://api.ocp-edge113-0.lab.eng.tlv2.redhat.com:6443"
+    ocp_version: "4.21"
+    password_env: "STORAGE_OFFLOAD_CLUSTER_EDGE113"
+```
+
+Each entry's `password_env` names the environment variable holding the kubeadmin password for that cluster. Add a new entry here (and the corresponding env var to `.env`) to onboard additional clusters.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make run        # run the container
 | `JENKINS_TOKEN` | Jenkins API token |
 | `REGISTRY_PROD_USER` / `REGISTRY_PROD_TOKEN` | Production registry credentials |
 | `REGISTRY_STAGE_USER` / `REGISTRY_STAGE_TOKEN` | Stage registry credentials |
-| `STORAGE_OFFLOAD_CLUSTER` | Kubeadmin password for ocp-edge112; required when MTV 2.11 storage offload is enabled |
+| `STORAGE_OFFLOAD_CLUSTER_EDGE112` | Kubeadmin password for ocp-edge112; required when MTV 2.11 storage offload is enabled |
 | `STORAGE_OFFLOAD_CLUSTER_EDGE113` | Kubeadmin password for ocp-edge113; required when MTV 2.12 storage offload is enabled |
 | `ROOTCOZ` | Rootcoz Bearer token for the Jenkins analyzer API |
 
@@ -260,7 +260,7 @@ storage_offload_clusters:
     custom_cluster_name: "ocp-edge112"
     ocp_api_url: "https://api.ocp-edge112-0.lab.eng.tlv2.redhat.com:6443"
     ocp_version: "4.20"
-    password_env: "STORAGE_OFFLOAD_CLUSTER"
+    password_env: "STORAGE_OFFLOAD_CLUSTER_EDGE112"
   "2.12":
     custom_cluster_name: "ocp-edge113"
     ocp_api_url: "https://api.ocp-edge113-0.lab.eng.tlv2.redhat.com:6443"

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ make run        # run the container
 | `JENKINS_TOKEN` | Jenkins API token |
 | `REGISTRY_PROD_USER` / `REGISTRY_PROD_TOKEN` | Production registry credentials |
 | `REGISTRY_STAGE_USER` / `REGISTRY_STAGE_TOKEN` | Stage registry credentials |
-| `STORAGE_OFFLOAD_CLUSTER` | Kubeadmin password for the default storage offload cluster (optional) |
-| `STORAGE_OFFLOAD_CLUSTER_EDGE113` | Kubeadmin password for ocp-edge113 (MTV 2.12+, optional) |
+| `STORAGE_OFFLOAD_CLUSTER` | Kubeadmin password for ocp-edge112; required when MTV 2.11 storage offload is enabled |
+| `STORAGE_OFFLOAD_CLUSTER_EDGE113` | Kubeadmin password for ocp-edge113; required when MTV 2.12 storage offload is enabled |
 | `ROOTCOZ` | Rootcoz Bearer token for the Jenkins analyzer API |
 
 ---

--- a/mtv_pipelines/auth/auth.py
+++ b/mtv_pipelines/auth/auth.py
@@ -8,7 +8,7 @@ REGISTRY_PROD_USER = "REGISTRY_PROD_USER"
 REGISTRY_PROD_TOKEN = "REGISTRY_PROD_TOKEN"
 REGISTRY_STAGE_USER = "REGISTRY_STAGE_USER"
 REGISTRY_STAGE_TOKEN = "REGISTRY_STAGE_TOKEN"
-STORAGE_OFFLOAD_CLUSTER = "STORAGE_OFFLOAD_CLUSTER"
+STORAGE_OFFLOAD_CLUSTER_EDGE112 = "STORAGE_OFFLOAD_CLUSTER_EDGE112"
 GITHUB_TOKEN = "GH_TOKEN"
 ROOTCOZ_TOKEN = "ROOTCOZ"
 
@@ -39,7 +39,7 @@ class JenkinsAuth:
 class StorageOffloadClusterAuth:
     """Kubeadmin password for storage-offload Jenkins jobs; env is per-cluster in config."""
 
-    def __init__(self, password_env: str = STORAGE_OFFLOAD_CLUSTER):
+    def __init__(self, password_env: str = STORAGE_OFFLOAD_CLUSTER_EDGE112):
         self.passwd = Auth(password_env).value
 
 

--- a/mtv_pipelines/auth/auth.py
+++ b/mtv_pipelines/auth/auth.py
@@ -37,8 +37,10 @@ class JenkinsAuth:
 
 
 class StorageOffloadClusterAuth:
-    def __init__(self):
-        self.passwd = Auth(STORAGE_OFFLOAD_CLUSTER).value
+    """Kubeadmin password for storage-offload Jenkins jobs; env is per-cluster in config."""
+
+    def __init__(self, password_env: str = STORAGE_OFFLOAD_CLUSTER):
+        self.passwd = Auth(password_env).value
 
 
 class RootcozAuth:

--- a/mtv_pipelines/config/config.py
+++ b/mtv_pipelines/config/config.py
@@ -123,6 +123,10 @@ def get_cluster_mappings() -> dict:
     return _parse_simple("cluster_mappings")
 
 
+def get_storage_offload_clusters() -> dict:
+    return _parse_simple("storage_offload_clusters")
+
+
 def get_root_cert_path() -> str:
     return _parse_simple("root_cert_path")
 

--- a/mtv_pipelines/config/config.yaml
+++ b/mtv_pipelines/config/config.yaml
@@ -8,6 +8,20 @@ mtv_cutoff_version: "2.10.5"
 # CPEs started with MTV 2.9.5 (https://github.com/kubev2v/forklift/commit/b2ba256c97a03ad47fb3717a50f92397b6b4a297)
 mtv_cpe_version_init: "2.9.5"
 
+# Storage offload copyoffload Jenkins jobs: MTV x.y -> lab cluster API
+# password_env: env var with kubeadmin password (default: STORAGE_OFFLOAD_CLUSTER)
+storage_offload_clusters:
+  "2.11":
+    custom_cluster_name: "ocp-edge112"
+    ocp_api_url: "https://api.ocp-edge112-0.lab.eng.tlv2.redhat.com:6443"
+    ocp_version: "4.20"
+    password_env: "STORAGE_OFFLOAD_CLUSTER"
+  "2.12":
+    custom_cluster_name: "ocp-edge113"
+    ocp_api_url: "https://api.ocp-edge113-0.lab.eng.tlv2.redhat.com:6443"
+    ocp_version: "4.21"
+    password_env: "STORAGE_OFFLOAD_CLUSTER_EDGE113"
+
 # Cluster to OCP version mapping
 # if you want to disable CI for some OCP version, use "none"
 cluster_mappings:

--- a/mtv_pipelines/config/config.yaml
+++ b/mtv_pipelines/config/config.yaml
@@ -9,13 +9,13 @@ mtv_cutoff_version: "2.10.5"
 mtv_cpe_version_init: "2.9.5"
 
 # Storage offload copyoffload Jenkins jobs: MTV x.y -> lab cluster API
-# password_env: env var with kubeadmin password (default: STORAGE_OFFLOAD_CLUSTER)
+# password_env: env var with kubeadmin password (default: STORAGE_OFFLOAD_CLUSTER_EDGE112)
 storage_offload_clusters:
   "2.11":
     custom_cluster_name: "ocp-edge112"
     ocp_api_url: "https://api.ocp-edge112-0.lab.eng.tlv2.redhat.com:6443"
     ocp_version: "4.20"
-    password_env: "STORAGE_OFFLOAD_CLUSTER"
+    password_env: "STORAGE_OFFLOAD_CLUSTER_EDGE112"
   "2.12":
     custom_cluster_name: "ocp-edge113"
     ocp_api_url: "https://api.ocp-edge113-0.lab.eng.tlv2.redhat.com:6443"

--- a/mtv_pipelines/pipelines/automatic_iib.py
+++ b/mtv_pipelines/pipelines/automatic_iib.py
@@ -620,8 +620,8 @@ async def trigger_jenkins_jobs(
                         job_url=job_url,
                     )
                 )
-            # Limit to 2.11 on 4.20
-            if "2.11" in version:
+            mtv_xy = ".".join(version.split(".")[:2])
+            if mtv_xy in config.get_storage_offload_clusters():
                 job = await jm.trigger_storage_offload(version, iib_short)
                 job_url_coro = await jm.get_job_info(
                     job["job_name"], job["job_number"]

--- a/mtv_pipelines/pipelines/automatic_iib.py
+++ b/mtv_pipelines/pipelines/automatic_iib.py
@@ -622,18 +622,20 @@ async def trigger_jenkins_jobs(
                 )
             mtv_xy = ".".join(version.split(".")[:2])
             if mtv_xy in config.get_storage_offload_clusters():
+                cluster_cfg = config.get_storage_offload_clusters()[mtv_xy]
+                storage_ocp = f'v{str(cluster_cfg["ocp_version"]).replace("v", "")}'
                 job = await jm.trigger_storage_offload(version, iib_short)
-                job_url_coro = await jm.get_job_info(
-                    job["job_name"], job["job_number"]
-                )
-                job_url = job_url_coro.get("url", "")
                 if job:
+                    job_url_coro = await jm.get_job_info(
+                        job["job_name"], job["job_number"]
+                    )
+                    job_url = job_url_coro.get("url", "")
                     results.append(
                         JenkinsJobDTO(
                             iib_version=iib_version,
                             job_name=job["job_name"],
                             build_number=job["job_number"],
-                            ocp_version="v4.20",
+                            ocp_version=storage_ocp,
                             job_url=job_url,
                         )
                     )

--- a/mtv_pipelines/pipelines/automatic_iib.py
+++ b/mtv_pipelines/pipelines/automatic_iib.py
@@ -621,8 +621,9 @@ async def trigger_jenkins_jobs(
                     )
                 )
             mtv_xy = ".".join(version.split(".")[:2])
-            if mtv_xy in config.get_storage_offload_clusters():
-                cluster_cfg = config.get_storage_offload_clusters()[mtv_xy]
+            clusters = config.get_storage_offload_clusters()
+            if mtv_xy in clusters:
+                cluster_cfg = clusters[mtv_xy]
                 storage_ocp = f'v{str(cluster_cfg["ocp_version"]).replace("v", "")}'
                 job = await jm.trigger_storage_offload(version, iib_short)
                 if job:

--- a/mtv_pipelines/pipelines/handle_pr.py
+++ b/mtv_pipelines/pipelines/handle_pr.py
@@ -484,6 +484,8 @@ async def trigger_jenkins_jobs(
             )
         mtv_xy = ".".join(version.split(".")[:2])
         if mtv_xy in config.get_storage_offload_clusters():
+            cluster_cfg = config.get_storage_offload_clusters()[mtv_xy]
+            storage_ocp = f'v{str(cluster_cfg["ocp_version"]).replace("v", "")}'
             job = await jm.trigger_storage_offload(version, iib_short)
             if job:
                 job_url_coro = await jm.get_job_info(
@@ -495,7 +497,7 @@ async def trigger_jenkins_jobs(
                         iib_version=iib_version,
                         job_name=job["job_name"],
                         build_number=job["job_number"],
-                        ocp_version="v4.20",
+                        ocp_version=storage_ocp,
                         job_url=job_url,
                     )
                 )

--- a/mtv_pipelines/pipelines/handle_pr.py
+++ b/mtv_pipelines/pipelines/handle_pr.py
@@ -483,8 +483,9 @@ async def trigger_jenkins_jobs(
                 )
             )
         mtv_xy = ".".join(version.split(".")[:2])
-        if mtv_xy in config.get_storage_offload_clusters():
-            cluster_cfg = config.get_storage_offload_clusters()[mtv_xy]
+        clusters = config.get_storage_offload_clusters()
+        if mtv_xy in clusters:
+            cluster_cfg = clusters[mtv_xy]
             storage_ocp = f'v{str(cluster_cfg["ocp_version"]).replace("v", "")}'
             job = await jm.trigger_storage_offload(version, iib_short)
             if job:

--- a/mtv_pipelines/pipelines/handle_pr.py
+++ b/mtv_pipelines/pipelines/handle_pr.py
@@ -482,8 +482,8 @@ async def trigger_jenkins_jobs(
                     job_url=job_url,
                 )
             )
-        # Limit to 2.11 on 4.20
-        if "2.11" in version:
+        mtv_xy = ".".join(version.split(".")[:2])
+        if mtv_xy in config.get_storage_offload_clusters():
             job = await jm.trigger_storage_offload(version, iib_short)
             if job:
                 job_url_coro = await jm.get_job_info(

--- a/mtv_pipelines/wrappers/jenkins.py
+++ b/mtv_pipelines/wrappers/jenkins.py
@@ -262,7 +262,12 @@ class JenkinsManager:
     ):
         mtv_xy = ".".join(mtv_version.split(".")[:2])
         cluster_cfg = config.get_storage_offload_clusters().get(mtv_xy, {})
-        ocp_version = cluster_cfg.get("ocp_version", "4.20")
+        ocp_version = cluster_cfg.get("ocp_version")
+        if not ocp_version:
+            logger.error(
+                f"Missing ocp_version for MTV {mtv_xy} in storage_offload_clusters"
+            )
+            return {}
         ocp_wv = ocp_version.replace("v", "")
 
         ci_args = self.get_storage_offload_args(mtv_version, ocp_version, iib)

--- a/mtv_pipelines/wrappers/jenkins.py
+++ b/mtv_pipelines/wrappers/jenkins.py
@@ -3,7 +3,7 @@ import time
 
 import jenkins
 from auth.auth import (
-    STORAGE_OFFLOAD_CLUSTER,
+    STORAGE_OFFLOAD_CLUSTER_EDGE112,
     JenkinsAuth,
     StorageOffloadClusterAuth,
 )
@@ -113,7 +113,7 @@ class JenkinsManager:
             )
             return {}
         password_env = cluster_cfg.get(
-            "password_env", STORAGE_OFFLOAD_CLUSTER
+            "password_env", STORAGE_OFFLOAD_CLUSTER_EDGE112
         )
         return {
             "USE_USER_CLUSTER_CREDENTIALS": True,

--- a/mtv_pipelines/wrappers/jenkins.py
+++ b/mtv_pipelines/wrappers/jenkins.py
@@ -2,7 +2,11 @@ import logging
 import time
 
 import jenkins
-from auth.auth import JenkinsAuth, StorageOffloadClusterAuth
+from auth.auth import (
+    STORAGE_OFFLOAD_CLUSTER,
+    JenkinsAuth,
+    StorageOffloadClusterAuth,
+)
 from config import config
 from models.dto import JenkinsJobDTO
 
@@ -100,12 +104,23 @@ class JenkinsManager:
     def get_storage_offload_args(
         self, mtv_version: str, ocp_version: str, iib: str
     ):
+        mtv_xy = ".".join(mtv_version.split(".")[:2])
+        cluster_cfg = config.get_storage_offload_clusters().get(mtv_xy)
+        if not cluster_cfg:
+            logger.warning(
+                f"MTV {mtv_xy} not in storage_offload_clusters; "
+                "skipping storage offload args"
+            )
+            return {}
+        password_env = cluster_cfg.get(
+            "password_env", STORAGE_OFFLOAD_CLUSTER
+        )
         return {
             "USE_USER_CLUSTER_CREDENTIALS": True,
-            "CUSTOM_CLUSTER_NAME": "ocp-edge112",
-            "OCP_API_URL": "https://api.ocp-edge112-0.lab.eng.tlv2.redhat.com:6443",
+            "CUSTOM_CLUSTER_NAME": cluster_cfg["custom_cluster_name"],
+            "OCP_API_URL": cluster_cfg["ocp_api_url"],
             "OCP_USERNAME": "kubeadmin",
-            "OCP_PASSWORD": StorageOffloadClusterAuth().passwd,
+            "OCP_PASSWORD": StorageOffloadClusterAuth(password_env).passwd,
             "OCP_VERSION": ocp_version,
             "DEPLOY_MTV": True,
             "IIB_NO": iib,
@@ -243,9 +258,11 @@ class JenkinsManager:
             return {}
 
     async def trigger_storage_offload(
-        self, mtv_version: str, iib: str, ocp_version: str = "v4.20"
+        self, mtv_version: str, iib: str
     ):
         mtv_xy = ".".join(mtv_version.split(".")[:2])
+        cluster_cfg = config.get_storage_offload_clusters().get(mtv_xy, {})
+        ocp_version = cluster_cfg.get("ocp_version", "4.20")
         ocp_wv = ocp_version.replace("v", "")
 
         ci_args = self.get_storage_offload_args(mtv_version, ocp_version, iib)

--- a/mtv_pipelines/wrappers/jenkins.py
+++ b/mtv_pipelines/wrappers/jenkins.py
@@ -270,7 +270,7 @@ class JenkinsManager:
             return {}
         ocp_wv = ocp_version.replace("v", "")
 
-        ci_args = self.get_storage_offload_args(mtv_version, ocp_version, iib)
+        ci_args = self.get_storage_offload_args(mtv_version, ocp_wv, iib)
         if not ci_args:
             logger.warning(
                 f"Missing arguments, can't trigger a job for {ocp_version}/{mtv_version}"


### PR DESCRIPTION
Map MTV 2.11/2.12 to ocp-edge112/ocp-edge113 with separate kubeadmin passwords via configurable password_env (STORAGE_OFFLOAD_CLUSTER vs STORAGE_OFFLOAD_CLUSTER_EDGE113). Trigger copyoffload when MTV x.y is listed in storage_offload_clusters.

## Summary

- Add `storage_offload_clusters` config map in `config.yaml` mapping MTV x.y → cluster name, API URL, OCP version, and `password_env`
- Replace hardcoded `ocp-edge112` / `"2.11" in version` logic with dynamic config-driven lookup in `automatic_iib.py` and `handle_pr.py`
- MTV 2.12 builds now automatically trigger `mtv-2.12-ocp-4.21-copyoffload-tests` on ocp-edge113, using a separate `STORAGE_OFFLOAD_CLUSTER_EDGE113` env var for the kubeadmin password
- Adding future clusters only requires a new entry in `config.yaml` + the corresponding env var in `.env`

## Pre-requisites before going live
- `STORAGE_OFFLOAD_CLUSTER_EDGE113=<edge113-kubeadmin-password>` must be added to the `.env` on the machine running the automation

## Test plan
- [ ] Verify existing 2.11 flow still triggers `mtv-2.11-ocp-4.20-copyoffload-tests` on ocp-edge112 unchanged
- [ ] After adding `STORAGE_OFFLOAD_CLUSTER_EDGE113` to `.env`, verify a 2.12 build triggers `mtv-2.12-ocp-4.21-copyoffload-tests` on ocp-edge113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage offload now selects target cluster per MTV minor (e.g., 2.11, 2.12), derives the target OCP version from config, and uses the cluster-specific password variable; triggers are skipped when no cluster is configured.

* **Documentation**
  * README and sample config expanded with storage_offload_clusters examples and guidance for kubeadmin password environment variable names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/mtv-releng/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->