### PR TITLE
feat: automatic upgrade pipeline triggers

### DIFF
--- a/mtv_pipelines/pipelines/automatic_iib.py
+++ b/mtv_pipelines/pipelines/automatic_iib.py
@@ -603,6 +603,49 @@ async def trigger_jenkins_jobs(
                     )
                 )
 
+            bundle_ver = fbc_repo.for_bundle.version
+            if bundle_ver.minor > 0:
+                major_upgrade_from = f"{bundle_ver.major}.{bundle_ver.minor - 1}"
+                job = await jm.trigger_upgrade(
+                    version,
+                    ocps[1],
+                    iib_short_for_target_ocp(iib_short, ocps[1]),
+                    major_upgrade_from,
+                )
+                if job:
+                    job_url_coro = await jm.get_job_info(job["job_name"], job["job_number"])
+                    job_url = job_url_coro.get("url", "")
+                    results.append(
+                        JenkinsJobDTO(
+                            iib_version=iib_version,
+                            job_name=job["job_name"],
+                            build_number=job["job_number"],
+                            ocp_version=ocps[1],
+                            job_url=job_url,
+                        )
+                    )
+
+            if bundle_ver.patch > 0:
+                minor_upgrade_from = f"{bundle_ver.major}.{bundle_ver.minor}"
+                job = await jm.trigger_upgrade(
+                    version,
+                    ocps[0],
+                    iib_short_for_target_ocp(iib_short, ocps[0]),
+                    minor_upgrade_from,
+                )
+                if job:
+                    job_url_coro = await jm.get_job_info(job["job_name"], job["job_number"])
+                    job_url = job_url_coro.get("url", "")
+                    results.append(
+                        JenkinsJobDTO(
+                            iib_version=iib_version,
+                            job_name=job["job_name"],
+                            build_number=job["job_number"],
+                            ocp_version=ocps[0],
+                            job_url=job_url,
+                        )
+                    )
+
             mtv_xy = ".".join(version.split(".")[:2])
             clusters = config.get_storage_offload_clusters()
             if mtv_xy in clusters:

--- a/mtv_pipelines/tests/test_wrappers.py
+++ b/mtv_pipelines/tests/test_wrappers.py
@@ -378,6 +378,59 @@ class TestJenkinsManager:
             result = run(mgr.trigger_release_gate("2.11.0", "v4.21", "iib-1"))
         assert result == {}
 
+    # -- get_upgrade_args / trigger_upgrade ------------------------------------
+
+    def test_upgrade_args_includes_upgrade_from_version(self, mgr):
+        with patch(
+            "wrappers.jenkins.config.get_cluster_mappings",
+            return_value={"4.21": "cluster-a"},
+        ):
+            args = mgr.get_upgrade_args("2.11.0", "4.21", "iib-123", "2.10")
+        assert args["CLUSTER_NAME"] == "cluster-a"
+        assert args["MATRIX_TYPE"] == "UPGRADE"
+        assert args["IIB_NO"] == "iib-123"
+        assert args["MTV_VERSION"] == "2.11.0"
+        assert args["OCP_VERSION"] == "4.21"
+        assert args["MTV_UPGRADE_FROM_VERSION"] == "2.10"
+
+    def test_upgrade_args_raises_on_unknown_ocp(self, mgr):
+        with patch(
+            "wrappers.jenkins.config.get_cluster_mappings",
+            return_value={"4.21": "cluster-a"},
+        ):
+            with pytest.raises(ValueError, match="not in cluster mappings"):
+                mgr.get_upgrade_args("2.11.0", "9.99", "iib-x", "2.10")
+
+    def test_upgrade_args_returns_empty_when_cluster_none(self, mgr):
+        with patch(
+            "wrappers.jenkins.config.get_cluster_mappings",
+            return_value={"4.21": "none"},
+        ):
+            args = mgr.get_upgrade_args("2.11.0", "4.21", "iib-x", "2.10")
+        assert args == {}
+
+    def test_trigger_upgrade_returns_job_info(self, mgr):
+        with (
+            patch(
+                "wrappers.jenkins.config.get_cluster_mappings",
+                return_value={"4.21": "cluster-a"},
+            ),
+            patch.object(mgr, "run_job", new_callable=AsyncMock, return_value=10),
+        ):
+            result = run(mgr.trigger_upgrade("2.11.0", "v4.21", "iib-1", "2.10"))
+        assert result["job_name"] == "mtv-2.11-ocp-4.21-test-release-upgrade"
+        assert result["job_number"] == 10
+
+    def test_trigger_upgrade_returns_empty_when_no_job(self, mgr):
+        with (
+            patch(
+                "wrappers.jenkins.config.get_cluster_mappings",
+                return_value={"4.21": "none"},
+            ),
+        ):
+            result = run(mgr.trigger_upgrade("2.11.0", "v4.21", "iib-1", "2.10"))
+        assert result == {}
+
 
 # ---------------------------------------------------------------------------
 # JenkinsAnalyzer

--- a/mtv_pipelines/wrappers/jenkins.py
+++ b/mtv_pipelines/wrappers/jenkins.py
@@ -196,6 +196,35 @@ class JenkinsManager:
         args["REMOTE_CLUSTER_NAME"] = cluster
         return args
 
+    def get_upgrade_args(
+        self, mtv_version: str, ocp_version: str, iib: str, upgrade_from_version: str
+    ) -> dict:
+        cluster_mappings = config.get_cluster_mappings()
+        args = self.get_mtv_ci_args()
+        args["IIB_NO"] = iib
+        args["MTV_VERSION"] = mtv_version
+        args["MTV_XY_VERSION"] = ".".join(mtv_version.split(".")[:2])
+        args["OCP_VERSION"] = ocp_version
+        args["OCP_XY_VERSION"] = ocp_version
+        args["PYTEST_EXTRA_PARAMS"] = args["PYTEST_EXTRA_PARAMS"].replace(
+            "{ocp}", ocp_version
+        )
+        args["MATRIX_TYPE"] = "UPGRADE"
+        args["MTV_UPGRADE_FROM_VERSION"] = upgrade_from_version
+        cluster = cluster_mappings.get(ocp_version, "")
+        if not cluster:
+            raise ValueError(
+                f"OCP {ocp_version} not in cluster mappings {cluster_mappings}"
+            )
+        if cluster.lower() == "none":
+            logger.warning(
+                f"OCP {ocp_version} disabled in cluster mappings {cluster_mappings}"
+            )
+            return {}
+        args["CLUSTER_NAME"] = cluster
+        args["REMOTE_CLUSTER_NAME"] = cluster
+        return args
+
     def get_ui_testing_args(
         self, mtv_version: str, iib: str, target_cluster: str
     ):
@@ -251,6 +280,27 @@ class JenkinsManager:
         ocp_wv = ocp_version.replace("v", "")
 
         job_name = f"mtv-{mtv_xy}-ocp-{ocp_wv}-test-release-non-gate"
+        job_number = await self.run_job(job_name, ci_args)
+        if job_number:
+            return {"job_name": job_name, "job_number": job_number}
+        else:
+            return {}
+
+    async def trigger_upgrade(
+        self, mtv_version: str, ocp_version: str, iib: str, upgrade_from_version: str
+    ) -> dict:
+        ci_args = self.get_upgrade_args(
+            mtv_version, ocp_version.replace("v", ""), iib, upgrade_from_version
+        )
+        if not ci_args:
+            logger.warning(
+                f"Missing arguments, can't trigger a job for {ocp_version}/{mtv_version}"
+            )
+            return {}
+        mtv_xy = ".".join(mtv_version.split(".")[:2])
+        ocp_wv = ocp_version.replace("v", "")
+
+        job_name = f"mtv-{mtv_xy}-ocp-{ocp_wv}-test-release-upgrade"
         job_number = await self.run_job(job_name, ci_args)
         if job_number:
             return {"job_name": job_name, "job_number": job_number}


### PR DESCRIPTION
Trigger upgrade Jenkins pipelines from automatic_iib for each new MTV build. Major upgrade runs against OCP latest-1 with MTV_UPGRADE_FROM_VERSION set to previous Y-stream. Minor upgrade runs against latest OCP with same Y-stream, skipped for initial versions (patch == 0).

Resolves: #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline now automatically triggers additional Jenkins upgrade jobs based on MTV bundle versions, testing both major and minor version upgrade scenarios against different OpenShift Container Platform versions.

* **Tests**
  * Added test coverage for upgrade workflow functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->