### PR TITLE
Fix MATRIX_TYPE for non-gate jobs: TIER1 -> RELEASE_NON_GATE

### DIFF
--- a/mtv_pipelines/tests/test_wrappers.py
+++ b/mtv_pipelines/tests/test_wrappers.py
@@ -346,13 +346,13 @@ class TestJenkinsManager:
 
     # -- get_test_release_non_gate_args --------------------------------------
 
-    def test_non_gate_args_sets_tier1_matrix(self, mgr):
+    def test_non_gate_args_sets_release_non_gate_matrix(self, mgr):
         with patch(
             "wrappers.jenkins.config.get_cluster_mappings",
             return_value={"4.21": "cluster-b"},
         ):
             args = mgr.get_test_release_non_gate_args("2.11.0", "4.21", "iib-456")
-        assert args["MATRIX_TYPE"] == "TIER1"
+        assert args["MATRIX_TYPE"] == "RELEASE_NON_GATE"
 
     # -- trigger_release_gate (async) ----------------------------------------
 

--- a/mtv_pipelines/wrappers/jenkins.py
+++ b/mtv_pipelines/wrappers/jenkins.py
@@ -181,7 +181,7 @@ class JenkinsManager:
         args["PYTEST_EXTRA_PARAMS"] = args["PYTEST_EXTRA_PARAMS"].replace(
             "{ocp}", ocp_version
         )
-        args["MATRIX_TYPE"] = "TIER1"
+        args["MATRIX_TYPE"] = "RELEASE_NON_GATE"
         cluster = cluster_mappings.get(ocp_version, "")
         if not cluster:
             raise ValueError(

--- a/scripts/BESPOKE_EXECUTION_GUIDE.md
+++ b/scripts/BESPOKE_EXECUTION_GUIDE.md
@@ -33,8 +33,8 @@ The scripts use JSON files to pass data between stages:
 **Arguments:**
 - `JOB_SUFFIX`: Job name suffix (default: `gate`, can be comma-separated, e.g., `gate`, `non-gate`, `gate,non-gate`)
 - `MATRIX_TYPE`: Matrix type (default: `RELEASE`)
-  - Single value: applies to all job suffixes (e.g., `RELEASE`, `FULL`, `STAGE`, `TIER1`)
-  - Mapping format: different matrix types per suffix (e.g., `gate:RELEASE,non-gate:FULL`)
+  - Single value: applies to all job suffixes (e.g., `RELEASE`, `RELEASE_NON_GATE`, `FULL`, `STAGE`, `TIER1`, `UPGRADE`)
+  - Mapping format: different matrix types per suffix (e.g., `gate:RELEASE,non-gate:RELEASE_NON_GATE`)
 
 **Examples:**
 ```bash
@@ -51,7 +51,7 @@ The scripts use JSON files to pass data between stages:
 ./scripts/jenkins_trigger.sh trigger 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-01' 'gate,non-gate' 'RELEASE'
 
 # Trigger both gate and non-gate jobs with different matrix types
-./scripts/jenkins_trigger.sh trigger 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-01' 'gate,non-gate' 'gate:RELEASE,non-gate:FULL'
+./scripts/jenkins_trigger.sh trigger 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-01' 'gate,non-gate' 'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 
 # Import jobs from previous run
 ./scripts/jenkins_trigger.sh import job_tracking.json
@@ -132,10 +132,10 @@ The scripts use JSON files to pass data between stages:
 ./scripts/jenkins_call.sh 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-02'
 
 # Both gate and non-gate jobs with different matrix types
-./scripts/jenkins_call.sh 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-01' 'gate,non-gate' 'gate:RELEASE,non-gate:FULL'
+./scripts/jenkins_call.sh 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-01' 'gate,non-gate' 'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 
 # Different clusters and matrix types for different job types
-./scripts/jenkins_call.sh 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'gate:qemtv-01,non-gate:qemtv-02' 'gate,non-gate' 'gate:RELEASE,non-gate:FULL'
+./scripts/jenkins_call.sh 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'gate:qemtv-01,non-gate:qemtv-02' 'gate,non-gate' 'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 ```
 
 ### 2. Trigger Only
@@ -170,7 +170,7 @@ The scripts use JSON files to pass data between stages:
 ### 5. Debugging Workflow
 ```bash
 # Step 1: Trigger jobs (with optional job suffix and matrix type)
-./scripts/jenkins_trigger.sh trigger 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-01' 'gate,non-gate' 'gate:RELEASE,non-gate:FULL'
+./scripts/jenkins_trigger.sh trigger 'forklift-fbc-prod-v420:on-pr-abc123' '2.10.0' '4.20' 'false' 'qemtv-01' 'gate,non-gate' 'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 
 # Step 2: Check what was triggered
 cat job_tracking.json
@@ -309,10 +309,12 @@ You can specify different clusters for each combination of OCP version and job s
 ### Matrix Types
 
 The `MATRIX_TYPE` parameter controls which test matrix is executed. Supported values include:
-- `RELEASE`: Release test matrix (default)
+- `RELEASE`: Release test matrix (default) - tier0 tests on all platforms (gate jobs)
+- `RELEASE_NON_GATE`: Release non-gate test matrix - tier0 tests on RHV, remote, and OpenStack platforms (non-gate release testing)
 - `FULL`: Full test matrix
 - `STAGE`: Stage test matrix
-- `TIER1`: Tier 1 test matrix
+- `TIER1`: Tier 1 test matrix (tier1 feature testing)
+- `UPGRADE`: Upgrade test matrix (cluster locking + major upgrade/minor update testing)
 
 #### Single Matrix Type (All Jobs)
 When you provide a single value, it applies to all job suffixes:
@@ -324,8 +326,8 @@ When you provide a single value, it applies to all job suffixes:
 #### Different Matrix Types Per Job Suffix
 You can specify different matrix types for different job suffixes using mapping format:
 ```bash
-# Gate jobs use RELEASE, non-gate jobs use FULL
-./scripts/jenkins_call.sh <IIB> <MTV_VERSION> <OCP_VERSIONS> <RC> <CLUSTER> 'gate,non-gate' 'gate:RELEASE,non-gate:FULL'
+# Gate jobs use RELEASE, non-gate jobs use RELEASE_NON_GATE
+./scripts/jenkins_call.sh <IIB> <MTV_VERSION> <OCP_VERSIONS> <RC> <CLUSTER> 'gate,non-gate' 'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 ```
 
 The mapping format is: `suffix1:type1,suffix2:type2`
@@ -374,11 +376,11 @@ You can combine cluster mapping and matrix type mapping for maximum flexibility:
 ```bash
 # Example 1: Different clusters per suffix, different matrix types per suffix
 # Gate jobs: qemtv-01 cluster with RELEASE matrix
-# Non-gate jobs: qemtv-02 cluster with FULL matrix
+# Non-gate jobs: qemtv-02 cluster with RELEASE_NON_GATE matrix
 ./scripts/jenkins_call.sh <IIB> <MTV_VERSION> <OCP_VERSIONS> <RC> \
   'gate:qemtv-01,non-gate:qemtv-02' \
   'gate,non-gate' \
-  'gate:RELEASE,non-gate:FULL'
+  'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 
 # Example 2: Different clusters per OCP version, same matrix type
 # OCP 4.19: qemtv-01, OCP 4.20: qemtv-02
@@ -388,12 +390,12 @@ You can combine cluster mapping and matrix type mapping for maximum flexibility:
   'RELEASE'
 
 # Example 3: Combined mapping with different matrix types
-# OCP 4.19 gate -> qemtv-01/RELEASE, OCP 4.19 non-gate -> qemtv-02/FULL
-# OCP 4.20 gate -> qemtv-03/RELEASE, OCP 4.20 non-gate -> qemtv-04/FULL
+# OCP 4.19 gate -> qemtv-01/RELEASE, OCP 4.19 non-gate -> qemtv-02/RELEASE_NON_GATE
+# OCP 4.20 gate -> qemtv-03/RELEASE, OCP 4.20 non-gate -> qemtv-04/RELEASE_NON_GATE
 ./scripts/jenkins_call.sh <IIB> <MTV_VERSION> '4.19,4.20' <RC> \
   '4.19:gate:qemtv-01,4.19:non-gate:qemtv-02,4.20:gate:qemtv-03,4.20:non-gate:qemtv-04' \
   'gate,non-gate' \
-  'gate:RELEASE,non-gate:FULL'
+  'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 
 # Example 4: Different IIB values per job
 # Gate jobs use one IIB, non-gate jobs use another
@@ -404,7 +406,7 @@ You can combine cluster mapping and matrix type mapping for maximum flexibility:
 ./scripts/jenkins_call.sh 'forklift-fbc-prod-v420:on-pr-abc123' <MTV_VERSION> '4.19,4.20' <RC> \
   '4.19:gate:qemtv-01,4.19:non-gate:qemtv-02,4.20:gate:qemtv-03,4.20:non-gate:qemtv-04' \
   'gate,non-gate' \
-  'gate:RELEASE,non-gate:FULL' \
+  'gate:RELEASE,non-gate:RELEASE_NON_GATE' \
   '4.19:gate:forklift-fbc-prod-v420:on-pr-abc123,4.19:non-gate:forklift-fbc-prod-v420:on-pr-xyz789,4.20:gate:forklift-fbc-prod-v420:on-pr-def456,4.20:non-gate:forklift-fbc-prod-v420:on-pr-ghi789'
 ```
 
@@ -450,7 +452,7 @@ Create a JSON config file (see `jenkins_config.example.json` for format):
   "matrix_types": {
     "by_suffix": {
       "gate": "RELEASE",
-      "non-gate": "FULL"
+      "non-gate": "RELEASE_NON_GATE"
     }
   },
   "job_suffixes": {
@@ -481,7 +483,7 @@ Set environment variables for cleaner calls:
 **Example:**
 ```bash
 export JENKINS_CLUSTER_MAP='4.19:gate:qemtv-01,4.19:non-gate:qemtv-02,4.20:gate:qemtv-03,4.20:non-gate:qemtv-04'
-export JENKINS_MATRIX_MAP='gate:RELEASE,non-gate:FULL'
+export JENKINS_MATRIX_MAP='gate:RELEASE,non-gate:RELEASE_NON_GATE'
 ./scripts/jenkins_call.sh <IIB> <MTV_VERSION> '4.19,4.20' <RC> '' 'gate,non-gate'
 ```
 
@@ -493,7 +495,7 @@ Pass mappings directly as arguments - perfect for automation where you want expl
 ./scripts/jenkins_call.sh <IIB> <MTV_VERSION> '4.19,4.20' <RC> \
   '4.19:gate:qemtv-01,4.19:non-gate:qemtv-02,4.20:gate:qemtv-03,4.20:non-gate:qemtv-04' \
   'gate,non-gate' \
-  'gate:RELEASE,non-gate:FULL'
+  'gate:RELEASE,non-gate:RELEASE_NON_GATE'
 ```
 
 **Priority Order (highest to lowest):**
@@ -512,8 +514,8 @@ The scripts send the following parameters to Jenkins jobs:
 - `GIT_BRANCH`: Git branch (main)
 - `IIB_NO`: Image Index Bundle
 - `MATRIX_TYPE`: Matrix type (default: RELEASE)
-  - Can be a single value (applies to all job suffixes): `RELEASE`, `FULL`, `STAGE`, `TIER1`
-  - Can be a mapping format (different types per suffix): `gate:RELEASE,non-gate:FULL`
+  - Can be a single value (applies to all job suffixes): `RELEASE`, `RELEASE_NON_GATE`, `FULL`, `STAGE`, `TIER1`, `UPGRADE`
+  - Can be a mapping format (different types per suffix): `gate:RELEASE,non-gate:RELEASE_NON_GATE`
 - `MTV_API_TEST_GIT_USER`: MTV API test git user (RedHatQE)
 - `MTV_SOURCE`: MTV source (KONFLUX)
 - `MTV_VERSION`: MTV version

--- a/scripts/automatic_iib.sh
+++ b/scripts/automatic_iib.sh
@@ -100,10 +100,10 @@ for version in $(echo $latest_shas | jq '. | keys.[]' -r); do
 
   if [[ $version == "2.11.0" ]]; then
     scripts/jenkins_trigger.sh trigger "$iib_short" "$version" '4.21' 'false' 'qemtv-01' 'gate' 'RELEASE'
-    scripts/jenkins_trigger.sh trigger "$iib_short" "$version" '4.20' 'false' 'qemtv-02' 'non-gate' 'TIER1'
+    scripts/jenkins_trigger.sh trigger "$iib_short" "$version" '4.20' 'false' 'qemtv-02' 'non-gate' 'RELEASE_NON_GATE'
   elif [[ $version == *"2.10"* ]]; then
     scripts/jenkins_trigger.sh trigger "$iib_short" "$version" '4.20' 'true' 'qemtv-02' 'gate' 'RELEASE'
-    scripts/jenkins_trigger.sh trigger "$iib_short" "$version" '4.19' 'false' 'qemtv-03' 'non-gate' 'TIER1'
+    scripts/jenkins_trigger.sh trigger "$iib_short" "$version" '4.19' 'false' 'qemtv-03' 'non-gate' 'RELEASE_NON_GATE'
   fi
 
   # for ocp in $(echo $ocp_urls | jq -r '. | keys.[]'); do

--- a/scripts/jenkins_config.json
+++ b/scripts/jenkins_config.json
@@ -12,7 +12,7 @@
   "matrix_types": {
     "by_suffix": {
       "gate": "RELEASE",
-      "non-gate": "TIER1"
+      "non-gate": "RELEASE_NON_GATE"
     }
   },
   "iibs": {


### PR DESCRIPTION
MTV-6061 introduced tier1 feature testing jobs with MATRIX_TYPE=TIER1 that use the tier1 pytest marker. Existing non-gate jobs were still using MATRIX_TYPE=TIER1, which now routes to the wrong test matrix.

Changed non-gate jobs to use MATRIX_TYPE=RELEASE_NON_GATE to ensure they route to getReleaseGateMatrixJobs() for release testing.

Updated:
- get_test_release_non_gate_args() in jenkins.py
- automatic_iib.sh trigger calls for 2.10/2.11 non-gate jobs
- jenkins_config.json matrix_types mapping
- test_wrappers.py assertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-gate release jobs now use the dedicated `RELEASE_NON_GATE` matrix type (instead of `TIER1`) to ensure correct Jenkins job selection.
  * Automated Jenkins trigger behavior and configuration were updated for the affected OCP/product version combinations.

* **Documentation**
  * Expanded the execution guide to include `RELEASE_NON_GATE` support and refreshed examples for matrix type and per-suffix mappings (including JSON, environment variables, and inline arguments).

* **Tests**
  * Updated assertions and test naming to match the new non-gate `MATRIX_TYPE` expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->